### PR TITLE
fix(lint): re-add ignores for stale Yarn artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,8 +2,18 @@
 
 # dependencies
 /node_modules
+
+# Stale Yarn / PnP artifacts. The project moved to npm, but an older
+# checkout can still have untracked leftovers (notably .yarn/cache and
+# .yarn/unplugged). Ignored defensively so they are neither committed by
+# accident nor traversed by `eslint --fix .` and `prettier --check .`.
+/.yarn/
+/.yarnrc.yml
+/yarn.lock
 /.pnp
 .pnp.js
+.pnp.cjs
+.pnp.loader.mjs
 
 # testing
 /coverage

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,4 +1,5 @@
 node_modules
+.yarn
 .next
 .contentlayer
 out

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -11,6 +11,9 @@ const eslintConfig = [
   {
     ignores: [
       'node_modules/**',
+      // Stale Yarn leftovers in an older checkout; `eslint --fix .` would
+      // otherwise traverse and rewrite files inside them.
+      '.yarn/**',
       '.next/**',
       '.contentlayer/**',
       'out/**',


### PR DESCRIPTION
Follow-up to #264, from a review comment that arrived after it merged. The comment was correct, and the problem is slightly broader than it described.

## Before this PR

#264 removed the Yarn ignore entries on the reasoning that the project no longer uses Yarn. But a `.yarn/` directory can still exist as **untracked leftovers** in any checkout predating the migration — `git rm` removed the tracked files, while `.yarn/cache` and `.yarn/unplugged` survive.

I reproduced it against a simulated `.yarn/cache`, and all three tools traversed it:

```
git status        →  ?? .yarn/
eslint .          →  ✖ 3 problems (3 errors)   inside .yarn/cache/fake-pkg.js
prettier --check  →  [warn] .yarn/cache/broken.json
```

Each is a distinct failure:

- **git** — untracked noise that could be committed by accident
- **eslint** — errors inside `.yarn/` make `npm run lint` fail. Worse, the script is `eslint --fix .`, so it would **rewrite files under `.yarn/`**
- **prettier** — `prettier --check .` fails

## After this PR

Ignores restored in all three places (`.gitignore`, `eslint.config.mjs`, `.prettierignore`).

Also covers the PnP artifacts, which were **never** actually matched. `.gitignore` had `/.pnp` and `.pnp.js` — neither matches `.pnp.cjs` or `.pnp.loader.mjs`, which are the files this repo genuinely committed until #242 removed them:

```
.pnp.cjs         NOT IGNORED
.pnp.loader.mjs  NOT IGNORED
.yarnrc.yml      NOT IGNORED
yarn.lock        NOT IGNORED
```

`yarn.lock` and `.yarnrc.yml` are ignored too, so a stray `yarn` invocation cannot silently reintroduce them into a repo that is now npm-only.

## Reason that prompted this change

Removing the ignores looked like correct cleanup — the project doesn't use Yarn anymore, so why ignore its files? The flaw is that ignore rules exist for files that *shouldn't* be there, which is exactly the case during a transition. Defensive ignores cost nothing.

## Test Plan

- [x] Reproduced the original problem: created `.yarn/cache/{fake-pkg.js,broken.json}` and confirmed git, eslint and prettier each picked them up
- [x] Re-ran the identical simulation after the fix — all three skip `.yarn/`, and a stray `.pnp.cjs` is ignored too
- [x] `npm run lint` clean
- [x] `npx prettier --check .` clean

No source or dependency changes; ignore files only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)