### PR TITLE
chore: remove remaining Yarn and PnP references

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,8 +2,6 @@
 
 # dependencies
 /node_modules
-/.pnp
-.pnp.js
 
 # testing
 /coverage

--- a/faq/github-pages-deployment.md
+++ b/faq/github-pages-deployment.md
@@ -53,42 +53,25 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v3
-      - name: Detect package manager
-        id: detect-package-manager
-        run: |
-          if [ -f "${{ github.workspace }}/yarn.lock" ]; then
-            echo "manager=yarn" >> $GITHUB_OUTPUT
-            echo "command=install" >> $GITHUB_OUTPUT
-            echo "runner=yarn" >> $GITHUB_OUTPUT
-            exit 0
-          elif [ -f "${{ github.workspace }}/package.json" ]; then
-            echo "manager=npm" >> $GITHUB_OUTPUT
-            echo "command=ci" >> $GITHUB_OUTPUT
-            echo "runner=npx --no-install" >> $GITHUB_OUTPUT
-            exit 0
-          else
-            echo "Unable to determine package manager"
-            exit 1
-          fi
       - name: Setup Node
         uses: actions/setup-node@v3
         with:
-          node-version: '18'
-          cache: ${{ steps.detect-package-manager.outputs.manager }}
+          node-version: '24'
+          cache: npm
       - name: Restore cache
         uses: actions/cache@v3
         with:
           path: |
             .next/cache
           # Generate a new cache whenever packages or source files change.
-          key: ${{ runner.os }}-nextjs-${{ hashFiles('**/package-lock.json', '**/yarn.lock') }}-${{ hashFiles('**.[jt]s', '**.[jt]sx') }}
+          key: ${{ runner.os }}-nextjs-${{ hashFiles('**/package-lock.json') }}-${{ hashFiles('**.[jt]s', '**.[jt]sx') }}
           # If source files changed but packages didn't, rebuild from a prior cache.
           restore-keys: |
-            ${{ runner.os }}-nextjs-${{ hashFiles('**/package-lock.json', '**/yarn.lock') }}-
+            ${{ runner.os }}-nextjs-${{ hashFiles('**/package-lock.json') }}-
       - name: Install dependencies
-        run: ${{ steps.detect-package-manager.outputs.manager }} ${{ steps.detect-package-manager.outputs.command }}
+        run: npm ci
       - name: Build project assets
-        run: ${{ steps.detect-package-manager.outputs.manager }} build
+        run: npm run build
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v2
         with:


### PR DESCRIPTION
Follow-up to #264. The project moved to npm, but a few references survived.

This replaces #265, which I closed — that one went the wrong direction by *adding* defensive Yarn ignores. See the reasoning below.

## Before this PR

- `.gitignore` carried `/.pnp` and `.pnp.js`
- `faq/github-pages-deployment.md` documented a workflow branching on whether `yarn.lock` or `package.json` was present

## After this PR

**`.gitignore`** — dropped `/.pnp` and `.pnp.js`. Neither ever matched anything: the files this repo actually committed were `.pnp.cjs` and `.pnp.loader.mjs`, removed in #242 when PnP was dropped for Tailwind 4. They were dead entries left over from the *previous* package-manager transition.

**`faq/github-pages-deployment.md`** — with a single package manager, the detection step is dead weight, so the example is npm-only. That also removes a latent bug: the generic `${{ steps.detect-package-manager.outputs.manager }} build` expanded to `npm build` for npm, which is not a valid script invocation. It now reads `npm ci` and `npm run build`. The example's `node-version` also went 18 → 24 to match `engines.node`.

## Deliberately not doing

**Not re-adding defensive ignores for stale `.yarn/` directories.** #265 proposed that, and it was wrong on its own terms — it argued "defensive ignores cost nothing" while simultaneously documenting that `/.pnp` and `.pnp.js` had sat unmatched for years. That *is* the cost, and this PR removes exactly that kind of cruft.

The scenario has also already passed. Verified: no `.yarn/` in the working tree, this is the only clone of the repo on the machine, and Vercel clones fresh per build. There is no pre-migration checkout left to protect.

## One reference intentionally left

`package-lock.json` line 7453 contains `"yarn": ">=1"`. That is `cross-env@7.0.3`'s own `engines` field, mirrored verbatim into the generated lockfile — not our configuration. Editing it would be reverted by the next `npm install`, and it has no effect.

It resolves itself: `cross-env` v10 drops the field entirely (`engines: { node: ">=20" }`), and that upgrade is already queued as Renovate PR #255.

## Test Plan

- [x] No `yarn` or `pnp` references remain in any tracked file, except the generated lockfile line above
- [x] `npm run build` passes on Node 24 — 10 documents, RSS + per-tag feeds
- [x] `npm run lint` clean
- [x] `npx prettier --check .` clean

No source or dependency changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)