### PR TITLE
chore(deps): remove unused image-size dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,6 @@
         "esbuild": "0.28.2",
         "github-slugger": "^2.0.0",
         "gray-matter": "^4.0.2",
-        "image-size": "1.2.1",
         "katex": "0.16.9",
         "next": "15.5.23",
         "next-contentlayer2": "0.5.8",
@@ -2328,9 +2327,9 @@
       "license": "MIT"
     },
     "node_modules/@emnapi/wasi-threads": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.1.tgz",
-      "integrity": "sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==",
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.3.tgz",
+      "integrity": "sha512-ELEBe8PsLvvJ6QMr0zLt8ffvOHW/dc1m3CEzNMg7aJUv3bMaoDtw2TXyDAwkYBuroxxuHEwhRTLJSe5sya547g==",
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -6054,10 +6053,33 @@
         "node": ">=14.0.0"
       }
     },
+    "node_modules/@unrs/resolver-binding-wasm32-wasi/node_modules/@emnapi/core": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.10.0.tgz",
+      "integrity": "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.2.1",
+        "tslib": "^2.4.0"
+      }
+    },
     "node_modules/@unrs/resolver-binding-wasm32-wasi/node_modules/@emnapi/runtime": {
       "version": "1.10.0",
       "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
       "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@unrs/resolver-binding-wasm32-wasi/node_modules/@emnapi/wasi-threads": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.1.tgz",
+      "integrity": "sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==",
       "dev": true,
       "license": "MIT",
       "optional": true,
@@ -10147,21 +10169,6 @@
         "node": ">= 4"
       }
     },
-    "node_modules/image-size": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/image-size/-/image-size-1.2.1.tgz",
-      "integrity": "sha512-rH+46sQJ2dlwfjfhCyNx5thzrv+dtmBIhPHk0zgRUukHzZ/kRueTJXoYYsclBaKcSMBWuGbOFXtioLpzTb5euw==",
-      "license": "MIT",
-      "dependencies": {
-        "queue": "6.0.2"
-      },
-      "bin": {
-        "image-size": "bin/image-size.js"
-      },
-      "engines": {
-        "node": ">=16.x"
-      }
-    },
     "node_modules/imagescript": {
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/imagescript/-/imagescript-1.3.1.tgz",
@@ -13701,15 +13708,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/queue": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/queue/-/queue-6.0.2.tgz",
-      "integrity": "sha512-iHZWu+q3IdFZFX36ro/lKBkSvfkztY5Y7HMiPlOUjhupPcG2JMfst2KKEpu5XndviX/3UhFbRngUPNKtgvtZiA==",
-      "license": "MIT",
-      "dependencies": {
-        "inherits": "~2.0.3"
       }
     },
     "node_modules/queue-microtask": {

--- a/package.json
+++ b/package.json
@@ -23,7 +23,6 @@
     "esbuild": "0.28.2",
     "github-slugger": "^2.0.0",
     "gray-matter": "^4.0.2",
-    "image-size": "1.2.1",
     "katex": "0.16.9",
     "next": "15.5.23",
     "next-contentlayer2": "0.5.8",


### PR DESCRIPTION
Renovate proposed `image-size` v2 (#261). The dependency turns out to be **unused**, so this removes it rather than upgrading it — retiring the PR permanently instead of bumping a package the project does not use.

## Before this PR

`image-size` was pinned as a direct dependency (`1.2.1`), inherited from the upstream template.

## After this PR

Removed. The evidence it is unused:

- **Zero source references** — `git grep image-size` across everything but `package.json` / `package-lock.json` returns nothing
- **Nothing else depends on it** — `npm ls image-size` resolved to the root package alone, and after removal the tree does not contain it at all

The natural assumption is that `remarkImgToJsx` needs it to compute intrinsic image dimensions, which is presumably why the template ships it. **It does not** — pliny bundles its own `probe-image-size`. The two only looked related because `image-size` is a substring of `probe-image-size`, which is what my initial grep matched. Worth stating plainly, since "the image plugin obviously needs the image-size package" is exactly the kind of assumption that would have made this a routine version bump.

## Test Plan

- [x] `npm run build` passes on Node 24 — 10 documents, RSS + per-tag feeds
- [x] **Images still render correctly**, which is the real check. `the-sweet-smell-of-success` produces eight `<img>` tags through `next/image` with correct intrinsic dimensions (`width="1280" height="850"`), confirming `remarkImgToJsx`'s dimension probing is unaffected
- [x] `npm run lint` clean
- [x] `npx prettier --check .` clean
- [x] Preview deploy — worth a glance at a post with images (`the-sweet-smell-of-success`, `2021-fort-collins-intersection-counts`)

## Remaining majors

`#266` next 16, `#259` typescript v7, `#256` eslint v10, `#253` katex 0.18 — each still needs its own PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)