### PR TITLE
fix(deps): patch katex to clear five advisories, and fail builds when rendering breaks

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
         "esbuild": "0.28.2",
         "github-slugger": "^2.0.0",
         "gray-matter": "^4.0.2",
-        "katex": "0.16.9",
+        "katex": "^0.16.47",
         "next": "15.5.23",
         "next-contentlayer2": "0.5.8",
         "next-themes": "^0.4.0",
@@ -10918,9 +10918,9 @@
       }
     },
     "node_modules/katex": {
-      "version": "0.16.9",
-      "resolved": "https://registry.npmjs.org/katex/-/katex-0.16.9.tgz",
-      "integrity": "sha512-fsSYjWS0EEOwvy81j3vRA8TEAhQhKiqO+FQaKWp0m39qwOzHVBgAUBIXWj1pB+O2W3fIpNa6Y9KSKCVbfPhyAQ==",
+      "version": "0.16.47",
+      "resolved": "https://registry.npmjs.org/katex/-/katex-0.16.47.tgz",
+      "integrity": "sha512-Eeo8Ys1doU1z+x8AZsPpQu+p/QcZBI5PeOo7QGQdy2x2m0MU/hYagBbGOmXwr5KVbEfVuWv9LpnQWeehogurjg==",
       "funding": [
         "https://opencollective.com/katex",
         "https://github.com/sponsors/katex"

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   "scripts": {
     "start": "next dev",
     "dev": "cross-env INIT_CWD=$PWD next dev",
-    "build": "cross-env INIT_CWD=$PWD next build && node ./scripts/postbuild.mjs",
+    "build": "cross-env INIT_CWD=$PWD next build && node ./scripts/postbuild.mjs && node ./scripts/verify-rendering.mjs",
     "serve": "next start",
     "analyze": "cross-env ANALYZE=true next build",
     "lint": "eslint --fix .",

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "esbuild": "0.28.2",
     "github-slugger": "^2.0.0",
     "gray-matter": "^4.0.2",
-    "katex": "0.16.9",
+    "katex": "^0.16.47",
     "next": "15.5.23",
     "next-contentlayer2": "0.5.8",
     "next-themes": "^0.4.0",

--- a/renovate.json
+++ b/renovate.json
@@ -1,4 +1,15 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": ["config:recommended", ":semanticCommits"]
+  "extends": ["config:recommended", ":semanticCommits"],
+  "packageRules": [
+    {
+      "description": [
+        "Hold katex on the 0.16 line. rehype-katex 7 depends on katex ^0.16.0, so bumping the top-level pin does not upgrade it — npm keeps a nested 0.16 for rehype-katex to render with while the app imports the newer stylesheet.",
+        "katex 0.18 drops the `.katex .base` rule that 0.16-generated markup still emits, so math ships unstyled while the build stays green (see #253).",
+        "Remove this rule once rehype-katex publishes a release depending on katex >=0.18, then bump both together."
+      ],
+      "matchPackageNames": ["katex"],
+      "allowedVersions": "^0.16"
+    }
+  ]
 }

--- a/scripts/verify-rendering.mjs
+++ b/scripts/verify-rendering.mjs
@@ -1,0 +1,110 @@
+/**
+ * Build-time smoke test for the markdown rendering pipeline.
+ *
+ * Reads the compiled output of data/blog/rendering-reference.mdx and asserts
+ * that (a) each markdown feature actually produced markup, and (b) every
+ * plugin-emitted class it relies on has a matching rule in the shipped CSS.
+ *
+ * (b) is the interesting half. A dependency bump can leave the build green
+ * while silently decoupling markup from styles — katex 0.18 did exactly this:
+ * npm kept a nested katex 0.16 for rehype-katex to render with, while the app
+ * imported 0.18's stylesheet, which no longer defines `.katex .base`. Nothing
+ * failed, and the only page with math is a draft, so no preview showed it.
+ *
+ * Reading contentlayer's output rather than a rendered page is deliberate:
+ * the fixture stays `draft: true` and never ships, but its markup is still
+ * generated on every build.
+ */
+import { readFileSync, readdirSync, existsSync } from 'fs'
+import path from 'path'
+
+const FIXTURE = '.contentlayer/generated/Blog/blog__rendering-reference.mdx.json'
+const CSS_DIR = '.next/static/css'
+
+/** Markup that must be produced, as class -> what it proves. */
+const REQUIRED_CLASSES = {
+  katex: 'inline math (remark-math + rehype-katex)',
+  'katex-display': 'display math block',
+  'remark-code-title': 'code block titles (remark-code-titles)',
+  'code-line': 'code blocks (rehype-prism-plus)',
+  'highlight-line': 'code line highlighting',
+  'line-number': 'code line numbers',
+  token: 'syntax highlighting tokens',
+  'csl-entry': 'citations (rehype-citation)',
+  footnotes: 'footnotes (remark-gfm)',
+}
+
+/** Emitted class -> CSS selector that must exist to style it. */
+const REQUIRED_STYLES = {
+  base: '.katex .base',
+  'katex-display': '.katex-display',
+  'remark-code-title': '.remark-code-title',
+  'code-line': '.code-line',
+  'highlight-line': '.highlight-line',
+  'line-number': '.line-number',
+  token: '.token',
+  'csl-entry': '.csl-entry',
+  footnotes: '.footnotes',
+}
+
+const fail = (msg) => {
+  console.error(`\n  ✖ rendering check failed\n\n${msg}\n`)
+  process.exit(1)
+}
+
+if (!existsSync(FIXTURE)) {
+  fail(
+    `  Could not find ${FIXTURE}\n` +
+      `  The rendering fixture is missing. If data/blog/rendering-reference.mdx\n` +
+      `  was deleted, remove this check from the build script too.`
+  )
+}
+
+const code = JSON.parse(readFileSync(FIXTURE, 'utf8')).body.code
+
+// Compiled MDX emits classes as className:"a b c" — parse them rather than
+// substring-matching, which false-positives ("base" inside "rebase").
+const emitted = new Set()
+for (const match of code.matchAll(/className:"([^"]+)"/g)) {
+  for (const cls of match[1].split(/\s+/)) emitted.add(cls)
+}
+
+const missingMarkup = Object.entries(REQUIRED_CLASSES)
+  .filter(([cls]) => !emitted.has(cls))
+  .map(([cls, what]) => `    .${cls} — ${what}`)
+
+if (missingMarkup.length) {
+  fail(
+    `  These features produced no markup in the rendering fixture:\n\n` +
+      missingMarkup.join('\n') +
+      `\n\n  A markdown plugin is likely broken or was removed.`
+  )
+}
+
+if (!existsSync(CSS_DIR)) {
+  fail(`  Could not find ${CSS_DIR} — run this after \`next build\`.`)
+}
+
+const css = readdirSync(CSS_DIR)
+  .filter((f) => f.endsWith('.css'))
+  .map((f) => readFileSync(path.join(CSS_DIR, f), 'utf8'))
+  .join('\n')
+
+const unstyled = Object.entries(REQUIRED_STYLES)
+  .filter(([cls, selector]) => emitted.has(cls) && !css.includes(selector))
+  .map(([cls, selector]) => `    class "${cls}" is emitted, but "${selector}" has no rule`)
+
+if (unstyled.length) {
+  fail(
+    `  Markup and stylesheet have drifted apart:\n\n` +
+      unstyled.join('\n') +
+      `\n\n  This usually means a package that renders markup and a package that\n` +
+      `  ships its stylesheet resolved to different versions. Check for duplicates:\n` +
+      `    npm ls katex`
+  )
+}
+
+console.log(
+  `Rendering check passed (${Object.keys(REQUIRED_CLASSES).length} features, ` +
+    `${Object.keys(REQUIRED_STYLES).length} style couplings).`
+)

--- a/scripts/verify-rendering.mjs
+++ b/scripts/verify-rendering.mjs
@@ -90,8 +90,21 @@ const css = readdirSync(CSS_DIR)
   .map((f) => readFileSync(path.join(CSS_DIR, f), 'utf8'))
   .join('\n')
 
+/**
+ * Whether `selector` appears in the stylesheet as a whole selector.
+ *
+ * A plain substring test would accept a longer class that merely starts with
+ * it — `.katex .baseline` would satisfy `.katex .base`, and `.token-list`
+ * would satisfy `.token` — silently defeating the drift check. Requiring the
+ * next character to be something that cannot continue a class name (so `{`
+ * `,` `:` `.` `>` `+` `~` `[` or whitespace) rules that out, while still
+ * matching compound selectors such as `.token.comment`.
+ */
+const hasRule = (selector) =>
+  new RegExp(`${selector.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}(?![\\w-])`).test(css)
+
 const unstyled = Object.entries(REQUIRED_STYLES)
-  .filter(([cls, selector]) => emitted.has(cls) && !css.includes(selector))
+  .filter(([cls, selector]) => emitted.has(cls) && !hasRule(selector))
   .map(([cls, selector]) => `    class "${cls}" is emitted, but "${selector}" has no rule`)
 
 if (unstyled.length) {


### PR DESCRIPTION
Three commits: a security patch, a build check that makes the class of bug which hid it impossible to miss again, and a Renovate constraint so the bad upgrade is not re-proposed.

## `f77b24a` — katex 0.16.9 → 0.16.47

`npm audit` reports **five moderate advisories** against katex 0.16.9, all fixed inside the 0.16 line:

- missing normalization of the protocol in URLs allows bypassing forbidden protocols (`<0.16.10`)
- `\includegraphics` does not escape filename (`<0.16.10`)
- `maxExpand` bypassed by Unicode sub/superscripts (`<0.16.10`)
- `maxExpand` bypassed by `\edef` (`<0.16.10`)
- `\htmlData` does not validate attribute names (`<=0.16.20`)

**Renovate could not surface this.** It offers only the newest version — `0.18.4` (#253) — which conflicts with `rehype-katex@7`'s `katex ^0.16.0`. Because that PR was unmergeable, the fixes available *within* 0.16 stayed invisible.

### #253 is not just blocked, it is actively wrong

npm does not upgrade in that situation, it **duplicates**:

```
├── katex@0.18.4                  ← app imports this stylesheet
├─┬ rehype-katex@7.0.1
│ └── katex@0.16.47               ← renders the markup
└─┬ micromark-extension-math@3.1.0
  └── katex@0.16.47
```

katex 0.18 drops the `.katex .base` rule that 0.16-generated markup still emits — measured on that branch: markup emits `class="base"` **4×**, the shipped 0.18 CSS has **0** matching rules, 0.16.47 has 2. Math would render unstyled.

**And every signal stayed green**: build compiled, typecheck passed, preview deployed. The only page with math is `draft: true`, so the preview rendered zero equations.

`0.16.47` satisfies `rehype-katex`'s range and dedupes to a single copy. **katex advisories: 5 → 0.**

I'd suggest closing #253 — 0.18 only becomes viable when `rehype-katex` ships a release depending on `katex ^0.18`.

## `f1f1c6b` — build-time rendering check

`scripts/verify-rendering.mjs` runs as the last step of `npm run build`, asserting against the rendering-reference fixture that:

1. every markdown feature produced markup (math, code titles, line highlighting, line numbers, syntax tokens, citations, footnotes)
2. **every plugin-emitted class it relies on has a matching rule in the shipped CSS**

Point 2 is the one that matters — it is the check that nothing else performs. Confirmed in both directions:

```
katex 0.16.47 → Rendering check passed (9 features, 9 style couplings).
katex 0.18.4  → build succeeds, then:
                ✖ class "base" is emitted, but ".katex .base" has no rule
```

**It reads contentlayer's generated output, not a rendered page**, so the fixture stays `draft: true` and never ships while still being exercised on every build. Classes are parsed from `className:"..."` rather than substring-matched — the naive approach false-positives, since `base` appears inside `rebase`.

### Scope, deliberately

This proves markup exists and is styled. It does **not** prove the page looks correct — wrong colours, broken layout and invisible text would all pass. Visual regression wants Playwright with computed-style assertions (more robust than pixel diffing across macOS/Linux font rendering), running in GitHub Actions rather than the Vercel build. Tracked separately.

On brittleness: most asserted selectors are **ours** — `.remark-code-title`, `.code-line`, `.highlight-line`, `.line-number` are defined in `css/prism.css`. If a plugin renames what it emits, this failing is *correct*, not spurious: those styles would have silently stopped applying.

## `0492e95` — hold katex on the 0.16 line in Renovate

Answering "can we tell Renovate about the incompatibility": yes, via `packageRules` + `allowedVersions`.

```json
{
  "description": [ "...why, in full..." ],
  "matchPackageNames": ["katex"],
  "allowedVersions": "^0.16"
}
```

The reasoning lives in the rule's own `description` field, so it is visible wherever the rule is read rather than only in a commit message.

The constraint is `^0.16` rather than an exact pin **on purpose**: 0.16.x patches still flow — which is exactly how the security bump in this PR would have arrived on its own — while the breaking majors are held. Verified: `0.16.47` allowed, `0.17.0` and `0.18.4` blocked.

Remove once `rehype-katex` publishes a release depending on `katex >=0.18`, then bump both together.

## Test Plan

- [x] `npm run build` passes on Node 24 — 10 documents, 32 static pages, RSS + per-tag feeds, rendering check green
- [x] Rendering check fails on a deliberately reintroduced katex 0.18.4, and the build itself still succeeds — proving the check catches what nothing else does
- [x] Math verified by temporarily un-drafting the fixture: inline math, display summation, `.katex-display`, `.katex-html` all render; draft flag restored
- [x] `npm run lint` and `npx prettier --check .` clean
- [x] Rendering check confirmed running in Vercel's build, not just locally: `Rendering check passed (9 features, 9 style couplings).`
- [x] Renovate constraint validated — 0.16.47 allowed, 0.17.0 / 0.18.4 blocked
- [ ] Preview deploy on the final commit

🤖 Generated with [Claude Code](https://claude.com/claude-code)
