### PR TITLE
test(build): fail the build when package.json and the lockfile disagree

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   "scripts": {
     "start": "next dev",
     "dev": "cross-env INIT_CWD=$PWD next dev",
-    "build": "cross-env INIT_CWD=$PWD next build && node ./scripts/postbuild.mjs && node ./scripts/verify-rendering.mjs",
+    "build": "node ./scripts/verify-lockfile.mjs && cross-env INIT_CWD=$PWD next build && node ./scripts/postbuild.mjs && node ./scripts/verify-rendering.mjs",
     "serve": "next start",
     "analyze": "cross-env ANALYZE=true next build",
     "lint": "eslint --fix .",

--- a/scripts/verify-lockfile.mjs
+++ b/scripts/verify-lockfile.mjs
@@ -1,0 +1,56 @@
+/**
+ * Fails the build when package.json and package-lock.json disagree about a
+ * direct dependency's version range.
+ *
+ * `npm install` — which Vercel runs — silently prefers the lockfile when the
+ * two disagree, so a dependency PR whose lockfile update failed builds green
+ * while installing the *old* version. Renovate's eslint v10 PR did exactly
+ * that: package.json said "^10.0.0", the lockfile still pinned 9.39.5, and
+ * Vercel installed eslint 9 and passed.
+ *
+ * `npm ci` would catch it, but cannot be used here: npm resolves a different
+ * optional-dependency tree on linux than on darwin (@emnapi/core and
+ * @emnapi/runtime get hoisted to the root at a different version), so a
+ * lockfile generated on macOS never satisfies `npm ci` on Vercel. This check
+ * compares only the declared ranges for direct dependencies, which is
+ * platform-independent.
+ */
+import { readFileSync } from 'fs'
+
+const pkg = JSON.parse(readFileSync('package.json', 'utf8'))
+const lock = JSON.parse(readFileSync('package-lock.json', 'utf8'))
+
+const root = lock.packages?.['']
+if (!root) {
+  console.error('\n  ✖ lockfile check failed\n\n  package-lock.json has no root package entry.\n')
+  process.exit(1)
+}
+
+const drift = []
+for (const field of ['dependencies', 'devDependencies', 'optionalDependencies']) {
+  for (const [name, declared] of Object.entries(pkg[field] ?? {})) {
+    const locked = root[field]?.[name]
+    if (locked === undefined) {
+      drift.push(`    ${name}: package.json declares "${declared}", missing from the lockfile`)
+    } else if (locked !== declared) {
+      drift.push(`    ${name}: package.json declares "${declared}", lockfile records "${locked}"`)
+    }
+  }
+}
+
+if (drift.length) {
+  console.error(
+    `\n  ✖ lockfile check failed\n\n` +
+      `  package.json and package-lock.json disagree:\n\n${drift.join('\n')}\n\n` +
+      `  The installed version follows the lockfile, so the build would use a\n` +
+      `  different version than package.json declares. Run \`npm install\` and\n` +
+      `  commit the updated lockfile.\n`
+  )
+  process.exit(1)
+}
+
+console.log(
+  `Lockfile check passed (${
+    Object.keys(root.devDependencies ?? {}).length + Object.keys(root.dependencies ?? {}).length
+  } direct dependencies in sync).`
+)


### PR DESCRIPTION
Adds `scripts/verify-lockfile.mjs`, run first in `npm run build`, so a `package.json` that disagrees with `package-lock.json` fails the build instead of silently passing.

**Note:** this started as `vercel.json` with `installCommand: "npm ci"`. That approach does not work here — explained below — so the PR now ships a platform-independent equivalent instead.

## Before this PR

Vercel runs `npm install`, which **prefers the lockfile** when the two disagree and downgrades the conflict to a warning.

Renovate's eslint v10 PR (#256) is the worked example. Its artifact update failed — `renovate/artifacts: Artifact file update failure` — so it changed `package.json` to `"^10.0.0"` and left the lockfile untouched. The PR contains **exactly one changed file**. Vercel then:

```
npm warn Found: eslint@9.39.5
npm warn   dev eslint@"^10.0.0" from the root project
```

…installed **eslint 9**, and passed. A green check on a PR whose entire purpose was to install eslint 10.

Merging it would leave `package.json` declaring a version nobody runs, until someone regenerated the lockfile — at which point `npm run lint` breaks on the `@eslint/eslintrc` that v10 no longer bundles, at a moment unrelated to the change that caused it.

## Why not `npm ci`

`npm ci` catches this precisely, and was the first attempt. **It cannot be used here.** npm resolves a different optional-dependency tree on linux than on darwin, and Vercel failed with:

```
npm error Missing: @emnapi/runtime@1.11.3 from lock file
npm error Missing: @emnapi/core@1.11.3 from lock file
```

On linux, `@emnapi/core` and `@emnapi/runtime` are hoisted to the lockfile root at **1.11.3**; a macOS-generated lockfile records **1.10.0**, nested under `@unrs/resolver-binding-wasm32-wasi`. Regenerating with `--package-lock-only`, and again with `--os=linux --cpu=x64`, produced neither entry.

So a lockfile generated on macOS can never satisfy `npm ci` on Vercel — that would require generating it on linux (a container in CI), which is a much larger ongoing commitment for every dependency change.

## After this PR

`scripts/verify-lockfile.mjs` compares only the **declared ranges of direct dependencies**, which is platform-independent and needs no install. It runs first in the build so it fails fast.

Verified in both directions:

```
main            → Lockfile check passed (44 direct dependencies in sync).
#256's change   → ✖ eslint: package.json declares "^10.0.0", lockfile records "^9.0.0"
```

## Deliberately not included

I earlier proposed pairing this with `git.deploymentEnabled: {"renovate/*": false}` for build-quota reasons. **That would now be counterproductive** — those previews are what catches this class of failure. The quota was exhausted by a bulk *"rebase all open PRs"* action (~27 rebases, each a build), not by routine previews; avoiding that action is the right mitigation.

## Reason that prompted this change

Three bugs this week shared a shape: a green build that didn't mean what it appeared to. katex 0.18 shipped a mismatched stylesheet (#271, rendering check); this one ships a manifest that disagrees with what's installed. Same category, different layer.

## Test Plan

- [x] `npm run build` passes on Node 24 — lockfile check, 10 documents, 32 static pages, RSS, rendering check
- [x] Check **fails** on a simulated #256 (range bumped, lockfile untouched) with the exact mismatch reported
- [x] `npm run lint` and `npx prettier --check .` clean
- [x] Confirmed `npm ci` fails on Vercel for the platform reason above, hence the pivot
- [ ] Preview deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)