### PR TITLE
build(renovate): hold eslint, typescript and next at blocked majors

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -10,6 +10,32 @@
       ],
       "matchPackageNames": ["katex"],
       "allowedVersions": "^0.16"
+    },
+    {
+      "description": [
+        "Hold eslint on v9. eslint-config-next 15.5.23 declares a peer of eslint '^7.23.0 || ^8.0.0 || ^9.0.0', so v10 cannot resolve; only eslint-config-next 16 widens that to '>=9.0.0' (see #256).",
+        "eslint 10 also stopped bundling @eslint/eslintrc, which eslint.config.mjs imports for FlatCompat, so that must be added as an explicit devDependency at the same time.",
+        "This is therefore gated behind the Next 16 upgrade. Remove once next and eslint-config-next reach 16 here."
+      ],
+      "matchPackageNames": ["eslint"],
+      "allowedVersions": "^9"
+    },
+    {
+      "description": [
+        "Hold typescript on v5. @typescript-eslint/parser 8.67.0 is the newest release and caps typescript at '>=4.8.4 <6.1.0', so v7 fails to install outright — npm errors with ERESOLVE, and even Renovate's own lockfile update fails (see #259).",
+        "Remove once typescript-eslint publishes a release supporting typescript 7."
+      ],
+      "matchPackageNames": ["typescript"],
+      "allowedVersions": "^5"
+    },
+    {
+      "description": [
+        "Hold the Next.js monorepo on v15. Next 16 makes Turbopack the default and withContentlayer injects a webpack config, so the build fails outright; contentlayer2 0.5.8 has no Turbopack support. `next build --webpack` defers that but not the rest (see #266).",
+        "Next 16 also rewrites tsconfig.json to moduleResolution 'bundler'. That part is already handled — #270 moved us there and mapped pliny explicitly, since pliny 0.4.1 ships no `types` conditions.",
+        "Remove once contentlayer2 supports Turbopack, or the project moves off contentlayer."
+      ],
+      "matchPackageNames": ["next", "@next/bundle-analyzer", "eslint-config-next"],
+      "allowedVersions": "^15"
     }
   ]
 }


### PR DESCRIPTION
Three major upgrades are blocked by **upstream packages, not by anything in this repo**. Renovate re-proposes them on every run, and each produces a PR that either cannot install or — worse — installs something misleading. This constrains all three, with the reasoning recorded in each rule's own `description` field so it is visible wherever the rule is read.

Companion to closing #256, #259 and #266.

## The holds

| Package(s) | Held at | Blocked by |
| --- | --- | --- |
| `eslint` | `^9` | `eslint-config-next@15.5.23` peers `^7 \|\| ^8 \|\| ^9`; only v16 widens to `>=9.0.0` |
| `typescript` | `^5` | `@typescript-eslint/parser@8.67.0` (newest release) caps `<6.1.0` |
| `next`, `@next/bundle-analyzer`, `eslint-config-next` | `^15` | contentlayer2 0.5.8 has no Turbopack support |
| `katex` | `^0.16` | *(already held in #271)* |

### eslint v10 (#256)

Gated behind Next 16, since only `eslint-config-next` 16 accepts it. That PR was also **actively misleading**: its lockfile update failed, so it changed `package.json` alone, and Vercel installed **eslint 9** while `package.json` declared `^10` — passing green. (PR #272 adds a build check for exactly that.)

eslint 10 additionally stopped bundling `@eslint/eslintrc`, which `eslint.config.mjs` imports for `FlatCompat`, so that becomes an explicit devDependency whenever this does land.

### typescript v7 (#259)

`@typescript-eslint/parser@8.67.0` is the newest release that exists — there is no v9 or v10 — and it caps TypeScript below 6.1. v7 fails outright with `ERESOLVE`; Renovate's own artifact update could not complete either.

### next 16 (#266)

Next 16 makes Turbopack the default while `withContentlayer` injects a webpack config, so the build fails at config validation. `next build --webpack` defers that but not the rest. The **tsconfig half is already done** — #270 moved to `moduleResolution: "bundler"` and mapped pliny explicitly, which is one of the three blockers cleared in advance.

## Why caret ranges, not exact pins

All four holds use carets, so **patches and minors continue to flow** — only the blocked majors are withheld. This matters: the katex hold added in #271 still allows the 0.16.x security patches, which is exactly how `0.16.47` reached us.

Verified the installed versions satisfy every rule: `eslint 9.39.5`, `typescript 5.9.3`, `next 15.5.23`, `katex 0.16.47`.

## Test Plan

- [x] `renovate.json` is valid JSON with 4 rules; `prettier --check` clean
- [x] Every currently installed version satisfies its hold — no rule immediately conflicts with the tree
- [ ] Preview deploy (no runtime effect; config only)

Each rule names the specific upstream release that unblocks it, so removal is a check rather than an investigation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)